### PR TITLE
Update grammar for Rails 5 models

### DIFF
--- a/Syntaxes/Ruby on Rails.plist
+++ b/Syntaxes/Ruby on Rails.plist
@@ -101,7 +101,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(^\s*)(?=class\s+.+ActiveRecord::Base)</string>
+			<string>(^\s*)(?=class\s+.+ApplicationRecord)|(?=class\s+.+ActiveRecord::Base)</string>
 			<key>comment</key>
 			<string>Uses lookahead to match classes that (may) inherit from ActiveRecord::Base; includes 'source.ruby' to avoid infinite recursion</string>
 			<key>end</key>


### PR DESCRIPTION
Rails 5 changed the convention for ActiveRecord model classes. Instead of inheriting directly from `ActiveRecord::Base`, the convention is apparently now to create a single abstract subclass of `Base`, by default called `ApplicationRecord`, and then have one's individual model classes inherit from that class. This commit alters the regex for the `meta.rails.model` scope definition to also look for `ApplicationRecord` at the top of a file in addition to `ActiveRecord::Base`.
